### PR TITLE
fix webmozart hash mismatch

### DIFF
--- a/pkgs/pixelfed/php-packages.nix
+++ b/pkgs/pixelfed/php-packages.nix
@@ -1560,7 +1560,7 @@ let
         name = "webmozart-assert-bafc69caeb4d49c39fd0779086c03a3738cbb389";
         src = fetchurl {
           url = https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389;
-          sha256 = "18jplwg4dsl86rqf1fvizbx84klmbvaq207a6i8gl97qxp20arlj";
+          sha256 = "0wd0si4c9r1256xj76vgk2slxpamd0wzam3dyyz0g8xgyra7201c";
         };
       };
     };


### PR DESCRIPTION
Verified using `nix-prefetch-url https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389`